### PR TITLE
Add NVM with Node 6 / 8 / 10, make Composer / Yarn / NPM builds optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN composer global require silverstripe/vendor-plugin-helper
 # NVM
 ENV NVM_DIR=/root/.nvm
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-RUN . /root/.nvm/nvm.sh && nvm install v8 && nvm install v6
+RUN . /root/.nvm/nvm.sh && nvm install v6 && nvm install v8 && nvm install v10
 
 COPY --from=build /funcs.sh /funcs.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php')
 RUN php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
 RUN composer global require silverstripe/vendor-plugin-helper
 
+# NVM
+ENV NVM_DIR=/root/.nvm
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+RUN . /root/.nvm/nvm.sh && nvm install v8 && nvm install v6
+
 COPY --from=build /funcs.sh /funcs.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM silverstripe/platform-build:1.0.2 AS build
 
 FROM stojg/node:8.1@sha256:fe45a08e0222a366125b73af3d71fdb741a2122221e5ef5f6f6d8b93de8d02e7
 
-RUN apt-get update && apt-get install -y curl php5-cli git
+RUN apt-get update && apt-get install -y curl php5-cli git jq
 
 RUN mkdir -p ~/.ssh
 RUN chmod 0700 ~/.ssh

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Platform Build Yarn
 
-Compacts a SilverStripe source code into a deployable state with composer
+Transforms a SilverStripe source code into a deployable state with Composer and Node
 
 This image is different from [silverstripeltd/platform-build](https://github.com/silverstripeltd/platform-build) in that it runs `yarn` and `yarn run` as well as composer. 
 
 
 ## What is this?
 
-This is a docker container that runs three commands:
+This is a docker container that runs multiple commands:
 
- - composer validate
- - composer install --no-progress --prefer-dist --no-dev --ignore-platform-reqs --optimize-autoloader --no-interaction --no-suggest
- - The silverstripe [vendor plugin](https://github.com/silverstripe/vendor-plugin-helper) `vendor-plugin-helper copy ./`
- - `yarn`
- - `yarn run`
+ - If a `composer.json` file is present:
+   - composer validate
+   - composer install --no-progress --prefer-dist --no-dev --ignore-platform-reqs --optimize-autoloader --no-interaction --no-suggest
+   - The silverstripe [vendor plugin](https://github.com/silverstripe/vendor-plugin-helper) `vendor-plugin-helper copy ./`
+ - If a `package.json` file is present:
+   - `yarn` or `npm install` (based on the presence of a `yarn.lock` file)
+   - `yarn run production` or `npm run production`
 
 ## Example usage
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,12 +44,16 @@ else
     echo "Using deploy key"
 fi
 
-composer_install
+if [[ -f composer.json ]]; then
+    composer_install
 
-vendor_expose
+    vendor_expose
+fi
 
-nvm_switch
+if [[ -f package.json ]]; then
+    nvm_switch
 
-yarn_install
+    yarn_install
+fi
 
 package_source ${SHA}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,11 +44,9 @@ else
     echo "Using deploy key"
 fi
 
-if [[ -f composer.json ]]; then
-    composer_install
+composer_install
 
-    vendor_expose
-fi
+vendor_expose
 
 if [[ -f package.json ]]; then
     nvm_switch

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ function yarn_install {
 	fi
 
 	echo "Running: Production Build Task"
-	yarn run --no-progress --non-interactive production
+	yarn run --no-progress --non-interactive scp-build
 
 	echo "Running: Purge Node Modules"
 	rm -rf node_modules/
@@ -48,7 +48,8 @@ composer_install
 
 vendor_expose
 
-if [[ -f package.json ]]; then
+# Only run the front-end build steps if the scp-build command is defined
+if [[ -f package.json && "`cat package.json | jq '.scripts["scp-build"]?'`" != "null" ]]; then
     nvm_switch
 
     yarn_install

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,11 +3,25 @@ set -e
 
 source /funcs.sh
 
-function yarn_install {
-	echo "Running: Yarn Dependency Installation"
-	yarn --no-progress --non-interactive
+function nvm_switch {
+	if [[ -f ".nvmrc" ]]; then
+		echo "Running: Apply NVM Configuration"
+		. /root/.nvm/nvm.sh
+		nvm use
+		which node
+	fi
+}
 
-	echo "Running: Webpack Production Build"
+function yarn_install {
+	if [[ -f "yarn.lock" ]]; then
+		echo "Running: Yarn Dependency Installation"
+		yarn --no-progress --non-interactive
+	else
+		echo "Running: NPM Dependency Installation"
+		npm install
+	fi
+
+	echo "Running: Production Build Task"
 	yarn run --no-progress --non-interactive production
 
 	echo "Running: Purge Node Modules"
@@ -33,6 +47,8 @@ fi
 composer_install
 
 vendor_expose
+
+nvm_switch
 
 yarn_install
 


### PR DESCRIPTION
This PR expands the image's flexibility, by adding [NVM](https://github.com/creationix/nvm) with Node v6, v8 and v10 preloaded. This enables the use of a `.nvmrc` file by projects to determine which version of Node should be used to compile their assets.

It also makes the build script determine whether to use Yarn or NPM, based on the existence of a `yarn.lock` file.

It _also_ makes the NPM / Yarn section of the build process entirely optional, based on the presence of `package.json`.